### PR TITLE
Fixing the build

### DIFF
--- a/src/reg/CMakeLists.txt
+++ b/src/reg/CMakeLists.txt
@@ -1,3 +1,5 @@
 add_library(reg reg.cpp)
 
+target_link_libraries(reg PUBLIC math_form)
+
 target_include_directories(reg PUBLIC include)

--- a/src/reg/reg.cpp
+++ b/src/reg/reg.cpp
@@ -4,8 +4,8 @@
 
 using namespace std;
 
-#include "reg.h"
-#include "math_form.h"
+#include <reg/reg.h>
+#include <math_form/math_form.h>
 
 void Regression::fit(){
 

--- a/test/reg_test.cpp
+++ b/test/reg_test.cpp
@@ -1,5 +1,5 @@
-#include "reg.h"
-#include "math_form.h"
+#include <reg/reg.h>
+#include <math_form/math_form.h>
 #include "const.h"
 #include <gtest/gtest.h>
 


### PR DESCRIPTION
With the current implementation we have two separate libraries: `reg` and `math_form`.
`reg` itself is depending on `math_form`. That's why changed the CMakeLists for `reg` to link the `math_form`. Note it's linked as PUBLIC instead of private. Since we need `math_form` to be linked to tests too, one way is to link in both CmakeLists and the other way to link publicly. 

Also fixed the includes.